### PR TITLE
Fixed problem with updateStage(), refactored tests, changed stageDurationBaseValue to 1 days

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ script:
   - npm run buidlerevm
   - sleep 5
   - npm run test
-  #- npm run coverage && cat coverage/lcov.info | coveralls
+  - npm run coverage && cat coverage/lcov.info | coveralls
   - npm run stop

--- a/buidler.config.js
+++ b/buidler.config.js
@@ -22,12 +22,6 @@ task("accounts", "Prints the list of accounts", async () => {
 // defaultNetwork, networks, solc, and paths.
 // Go to https://buidler.dev/config/ to learn more
 module.exports = {
-  defaultNetwork: 'localhost',
-  networks: {
-    localhost: {
-      url: 'http://localhost:8545'
-    },
-  },
   solc: {
     version: '0.6.8',
     optimizer: {
@@ -35,8 +29,14 @@ module.exports = {
       runs: 10000
     }
   },
-  coverage: {
-    url: 'http://localhost:8555'
+  defaultNetwork: 'buidlerevm',
+  networks: {
+    localhost: {
+      url: 'http://localhost:8545'
+    },
+    coverage: {
+      url: 'http://localhost:8555'
+    },
   },
   gasReporter: {
     currency: 'EUR'

--- a/contracts/ArborVote.sol
+++ b/contracts/ArborVote.sol
@@ -21,7 +21,7 @@ contract ArborVote {
     uint public votingStartTime;
     uint public countingStartTime;
 
-    uint constant stageDurationBaseValue = 10 minutes;
+    uint constant stageDurationBaseValue = 1 days;
 
     constructor (string memory _text) public {
         arguments[0] = Argument({ // Argument 0 is the proposal itself

--- a/contracts/ArborVote.sol
+++ b/contracts/ArborVote.sol
@@ -13,10 +13,6 @@ contract ArborVote {
     }
     Stage public stage = Stage.Init;
 
-    function getStage() public view returns (Stage) {
-        return stage;
-    }
-
     uint public debatingStartTime;
     uint public votingStartTime;
     uint public countingStartTime;
@@ -69,39 +65,6 @@ contract ArborVote {
     mapping ( uint8 => Argument ) public arguments;
 
     // Getters
-
-    function getIsFinalized(uint8 id) public view returns (bool) {
-        return arguments[id].isFinalized;
-    }
-
-    function getIsSupporting(uint8 id) public view returns (bool) {
-        return arguments[id].isSupporting;
-    }
-
-    function getParentId(uint8 id) public view returns (uint8) {
-        return arguments[id].parentId;
-    }
-
-    function getAccumulatedChildVotes(uint8 id) public view returns (int) {
-        return arguments[id].accumulatedChildVotes;
-    }
-
-    function getAccumulatedVotes(uint8 id) public view returns (int) {
-        return arguments[id].votes + arguments[id].accumulatedChildVotes;
-    }
-
-    function getVotes(uint8 id) public view returns (int) {
-        return arguments[id].votes;
-    }
-
-    function getText(uint8 id) public view returns (string memory) {
-        return arguments[id].text;
-    }
-
-    function getUnfinalizedChildCount(uint8 id) public view returns (uint8) {
-        return arguments[id].unfinalizedChildCount;
-    }
-
     function addArgument(uint8 _parentId, string memory _text, bool _supporting) public {
         updateStage();
         require(stage == Stage.Debating);
@@ -183,10 +146,6 @@ contract ArborVote {
         bool joined;
     }
     mapping (address => Voter) public voters;
-
-    function getJoined() public view returns (bool) {
-        return voters[msg.sender].joined;
-    }
 
     function getVoteTokens() public view returns (uint8) {
         return voters[msg.sender].voteTokens;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "stop": "sudo kill `sudo lsof -t -i:8545`",
     "compile": "buidler compile --force",
     "test": "buidler test --network buidlerevm",
-    "coverage": "buidler coverage --network buidlerevm"
+    "coverage": "buidler coverage --network coverage"
   },
   "devDependencies": {
     "@nomiclabs/buidler": "^1.3.8",

--- a/test/ArborVote-test.js
+++ b/test/ArborVote-test.js
@@ -37,7 +37,7 @@ describe("constructor", async function () {
   });
 
   it('should set the stage to "Debating"', async function () {
-    expect(await arborVote.stage()).to.equal(1);
+    expect(await arborVote.currentStage()).to.equal(1);
   });
 });
 
@@ -90,7 +90,7 @@ describe("vote", async function () {
     };
 
     await arborVote.advanceStage();
-    expect(await arborVote.stage()).to.equal(2);
+    expect(await arborVote.currentStage()).to.equal(2);
 
     // vote on arg 1 (id=1)
     await voteAndCheckHelper(1, 2).catch(function (err) {
@@ -118,11 +118,11 @@ describe("vote", async function () {
   });
 });
 
-describe("finalizeLeaves", function () {
+describe("finalizeLeaves", async function () {
 
   it("should finalize the arguments.", async function () {
     await arborVote.advanceStage();
-    expect(await arborVote.stage()).to.equal(3);
+    expect(await arborVote.currentStage()).to.equal(3);
 
     await arborVote.finalizeLeaves();
 

--- a/test/ArborVote-test.js
+++ b/test/ArborVote-test.js
@@ -1,5 +1,5 @@
-const { expect } = require("chai");
-const { utils } = require('ethers').utils;
+const {expect} = require("chai");
+const {utils} = require('ethers').utils;
 
 let arborVote;
 
@@ -10,7 +10,6 @@ before(async function () {
 
   // join
   await arborVote.join();
-  expect(await arborVote.getVoteTokens()).to.equal(12);
 
   // Layer 1
   await arborVote.addArgument(0, "1", true); // id 1
@@ -25,115 +24,128 @@ before(async function () {
   await arborVote.addArgument(3, "1.1.1", true); // id 6
 });
 
-describe("Constructor", function() {
-  it("should return the root thesis after the constructor was executed.", async function() {
-    expect(await arborVote.getText(0)).to.equal("Trees are great!");
+describe("Initial vote tokens", function () {
+  it('should be 12', async function () {
+    expect(await arborVote.INITIALVOTETOKENS()).to.equal(12);
+  });
+});
+
+describe("constructor", async function () {
+  it("should return the root thesis after the constructor was executed.", async function () {
+    const root = await arborVote.arguments(0);
+    expect(await root.text).to.equal("Trees are great!");
   });
 
   it('should set the stage to "Debating"', async function () {
-    expect(await arborVote.getStage()).to.equal(1);
+    expect(await arborVote.stage()).to.equal(1);
   });
 });
 
-describe("addArgument", function() {
-  it("should assign the argument ids.", async function() {
-    expect(await arborVote.getText(1)).to.equal("1");
-    expect(await arborVote.getText(2)).to.equal("2");
-    expect(await arborVote.getText(3)).to.equal("1.1");
-    expect(await arborVote.getText(4)).to.equal("1.2");
-    expect(await arborVote.getText(5)).to.equal("2.1");
-    expect(await arborVote.getText(6)).to.equal("1.1.1");
+describe("addArgument", async function () {
+
+  it("should assign the argument ids.", async function () {
+    for (let arr of [[1, "1"], [2, "2"], [3, "1.1"], [4, "1.2"], [5, "2.1"], [6, "1.1.1"]]) {
+      let id = arr[0], expected = arr[1];
+      const arg = await arborVote.arguments(id);
+      expect(arg.text).to.equal(expected);
+    }
   });
 
-  it("should display arguments as pro and con arguments.", async function() {
-    expect(await arborVote.getIsSupporting(1)).to.equal(true);
-    expect(await arborVote.getIsSupporting(2)).to.equal(false);
-    expect(await arborVote.getIsSupporting(3)).to.equal(true);
-    expect(await arborVote.getIsSupporting(4)).to.equal(false);
-    expect(await arborVote.getIsSupporting(5)).to.equal(true);
-    expect(await arborVote.getIsSupporting(6)).to.equal(true);
+  it("should display arguments as pro and con arguments.", async function () {
+
+    for (let arr of [[1, true], [2, false], [3, true], [4, false], [5, true], [6, true]]) {
+      let id = arr[0], expected = arr[1];
+      const arg = await arborVote.arguments(id);
+      expect(arg.isSupporting).to.equal(expected);
+    }
   });
 
-  it("should return the number of children.", async function() {
-    expect(await arborVote.getUnfinalizedChildCount(0)).to.equal(2);
-    expect(await arborVote.getUnfinalizedChildCount(1)).to.equal(2);
-    expect(await arborVote.getUnfinalizedChildCount(2)).to.equal(1);
-    expect(await arborVote.getUnfinalizedChildCount(3)).to.equal(1);
-    expect(await arborVote.getUnfinalizedChildCount(4)).to.equal(0);
-    expect(await arborVote.getUnfinalizedChildCount(5)).to.equal(0);
-    expect(await arborVote.getUnfinalizedChildCount(6)).to.equal(0);
+  it("should return the number of children.", async function () {
+    for (let arr of [[0, 2], [1, 2], [2, 1], [3, 1], [4, 0], [5, 0], [6, 0]]) {
+      let id = arr[0], expected = arr[1];
+      const arg = await arborVote.arguments(id);
+      expect(arg.unfinalizedChildCount).to.equal(expected);
+    }
   });
 });
 
-describe("vote", function() {
-  it("should change the number of votes and vote tokens left.", async function() {
+
+describe("vote", async function () {
+  it("should change the number of votes and vote tokens left.", async function () {
+
+    const voteAndCheckHelper = async function checkVote(id, voteStrength) {
+      const voteTokensBefore = await arborVote.getVoteTokens();
+      let arg = await arborVote.arguments(id);
+      const argumentVotesBefore = await arg.votes;
+
+      if(voteStrength >= 0)
+        await arborVote.voteFor(id, voteStrength);
+      else
+        await arborVote.voteAgainst(id, Math.abs(voteStrength));
+
+      expect(await arborVote.getVoteTokens()).to.equal(Number(voteTokensBefore) - Math.pow(voteStrength, 2));
+
+      arg = await arborVote.arguments(id);
+      expect(arg.votes).to.equal(Number(argumentVotesBefore) + voteStrength);
+    };
+
     await arborVote.advanceStage();
-    expect(await arborVote.getStage()).to.equal(2);
+    expect(await arborVote.stage()).to.equal(2);
 
-    // vote on arg 1
-    expect(await arborVote.getVotes(1)).to.equal(0);
-    await arborVote.voteFor(1, 2);
-    expect(await arborVote.getVoteTokens()).to.equal(8);
-    expect(await arborVote.getVotes(1)).to.equal(2);
+    // vote on arg 1 (id=1)
+    await voteAndCheckHelper(1, 2).catch(function (err) {
+      console.log(err);
+    });
 
-    // vote on arg 2
-    expect(await arborVote.getVotes(2)).to.equal(0);
-    await arborVote.voteFor(2, 2);
-    expect(await arborVote.getVoteTokens()).to.equal(4);
-    expect(await arborVote.getVotes(2)).to.equal(2);
+    // vote on arg 2 (id=2)
+    await voteAndCheckHelper(2, 2).catch(function (err) {
+      console.log(err);
+    });
 
-    await arborVote.voteAgainst(2, 1);
-    expect(await arborVote.getVoteTokens()).to.equal(3);
-    expect(await arborVote.getVotes(2)).to.equal(1);
+    await voteAndCheckHelper(2, -1).catch(function (err) {
+      console.log(err);
+    });
 
-    // vote on arg 1.1
-    expect(await arborVote.getVotes(3)).to.equal(0);
-    await arborVote.voteFor(3, 1);
-    expect(await arborVote.getVoteTokens()).to.equal(2);
-    expect(await arborVote.getVotes(2)).to.equal(1);
+    // vote on arg 1.1 (id=3)
+    await voteAndCheckHelper(3, 1).catch(function (err) {
+      console.log(err);
+    });
 
-    // vote on arg 1.1.1
-    expect(await arborVote.getVotes(6)).to.equal(0);
-    await arborVote.voteAgainst(6, 1);
-    expect(await arborVote.getVoteTokens()).to.equal(1);
-    expect(await arborVote.getVotes(6)).to.equal(-1); // => bad argument, cumulative vote weight is 0
+    // vote on arg 1.1.1 (id=6)
+    await voteAndCheckHelper(6, -1).catch(function (err) {
+      console.log(err);
+    });
   });
 });
 
-describe("finalizeLeaves", function() {
-  it("should finalize the arguments.", async function() {
+describe("finalizeLeaves", function () {
+
+  it("should finalize the arguments.", async function () {
     await arborVote.advanceStage();
-    expect(await arborVote.getStage()).to.equal(3);
+    expect(await arborVote.stage()).to.equal(3);
 
     await arborVote.finalizeLeaves();
 
-    expect(await arborVote.getIsFinalized(6)).to.equal(true);
-    expect(await arborVote.getIsFinalized(5)).to.equal(true);
-    expect(await arborVote.getIsFinalized(4)).to.equal(true);
-    expect(await arborVote.getIsFinalized(3)).to.equal(true);
-    expect(await arborVote.getIsFinalized(2)).to.equal(true);
-    expect(await arborVote.getIsFinalized(1)).to.equal(true);
-    expect(await arborVote.getIsFinalized(0)).to.equal(true);
+    for (let id of [6, 5, 4, 3, 2, 1]) {
+      const arg = await arborVote.arguments(id);
+      expect(arg.isFinalized).to.equal(true);
+    }
   });
 
-
-  it("should accumulate the child votes correctly.", async function() {
-    expect(await arborVote.getAccumulatedChildVotes(6)).to.equal(0);
-    expect(await arborVote.getAccumulatedChildVotes(5)).to.equal(0);
-    expect(await arborVote.getAccumulatedChildVotes(4)).to.equal(0);
-    expect(await arborVote.getAccumulatedChildVotes(3)).to.equal(0); // Arg 1.1.1 is a bad argument and returns 0
-    expect(await arborVote.getAccumulatedChildVotes(2)).to.equal(0);
-    expect(await arborVote.getAccumulatedChildVotes(1)).to.equal(1);
-    expect(await arborVote.getAccumulatedChildVotes(0)).to.equal(2);
+  it("should accumulate the child votes correctly.", async function () {
+    // Arg 1.1.1 (id=6) is a bad argument and results in Arg 1.1 (id=3) having 0 accumulated child votes
+    for (let arr of [[6, 0], [5, 0], [4, 0], [3, 0], [2, 0], [1, 1], [0, 2]]) {
+      const id = arr[0], expected = arr[1];
+      const arg = await arborVote.arguments(id);
+      expect(arg.accumulatedChildVotes).to.equal(expected);
+    }
   });
 
-  it("should accumulate the votes correctly.", async function() {
-    expect(await arborVote.getAccumulatedVotes(6)).to.equal(-1);
-    expect(await arborVote.getAccumulatedVotes(5)).to.equal(0);
-    expect(await arborVote.getAccumulatedVotes(4)).to.equal(0);
-    expect(await arborVote.getAccumulatedVotes(3)).to.equal(1); // Arg 1.1.1 is a bad argument and returns 0
-    expect(await arborVote.getAccumulatedVotes(2)).to.equal(1);
-    expect(await arborVote.getAccumulatedVotes(1)).to.equal(3);
-    expect(await arborVote.getAccumulatedVotes(0)).to.equal(2);
+  it("should accumulate the votes correctly.", async function () {
+    for (let arr of [[6, -1], [5, 0], [4, 0], [3, 1], [2, 1], [1, 3], [0, 2]]) {
+      const id = arr[0], expected = arr[1];
+      const arg = await arborVote.arguments(id);
+      expect(Number(await arg.votes) + Number(await arg.accumulatedChildVotes)).to.equal(expected);
+    }
   });
 });


### PR DESCRIPTION
A strange timing problem could be resolved (after posting an [issue in the `solidity-coverage` repo](https://github.com/sc-forks/solidity-coverage/issues/525)) **but is still not fully understood.**
`npm run test` worked but `npm run coverage` did not. This was somehow related to `updateStage()` and `advanceStage()` going back to older stages.
Preventing going back to an earlier stage in `updateStage()` solved the problem.
This is needed anyway since it is dangerous to rely solely on block times, [which can be influenced by miners]a(https://solidity.readthedocs.io/en/latest/units-and-global-variables.html#time-units)



